### PR TITLE
gptqmodel need use checkpoint_format

### DIFF
--- a/src/transformers/quantizers/quantizer_gptq.py
+++ b/src/transformers/quantizers/quantizer_gptq.py
@@ -78,11 +78,13 @@ class GptqHfQuantizer(HfQuantizer):
             raise RuntimeError("We can only quantize pure text model.")
 
         if self.pre_quantized:
-            model = self.optimum_quantizer.convert_model(model)
+            model = self.optimum_quantizer.convert_model(model, **kwargs)
+        else:
+            self.optimum_quantizer.quantize_preprocess(model, **kwargs)
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
         if self.pre_quantized:
-            model = self.optimum_quantizer.post_init_model(model)
+            model = self.optimum_quantizer.post_init_model(model, **kwargs)
         else:
             if self.quantization_config.tokenizer is None:
                 self.quantization_config.tokenizer = model.name_or_path

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -575,6 +575,8 @@ class GPTQConfig(QuantizationConfigMixin):
             Whether to perform sequential quantization even within a single Transformer block. Instead of quantizing
             the entire block at once, we perform layer-wise quantization. As a result, each layer undergoes
             quantization using inputs that have passed through the previously quantized layers.
+        checkpoint_format (`str`, *optional*, defaults to `gptq`):
+            GPTQ weight format. `gptq`(v1) is supported by both gptqmodel and auto-gptq. `gptq_v2` is only  gptqmodel only.
         use_cuda_fp16 (`bool`, *optional*, defaults to `False`):
             Whether or not to use optimized cuda kernel for fp16 model. Need to have model in fp16.
         model_seqlen (`int`, *optional*):
@@ -616,6 +618,7 @@ class GPTQConfig(QuantizationConfigMixin):
         desc_act: bool = False,
         sym: bool = True,
         true_sequential: bool = True,
+        checkpoint_format: Optional[str] = "gptq",
         use_cuda_fp16: bool = False,
         model_seqlen: Optional[int] = None,
         block_name_to_quantize: Optional[str] = None,
@@ -624,7 +627,6 @@ class GPTQConfig(QuantizationConfigMixin):
         pad_token_id: Optional[int] = None,
         use_exllama: Optional[bool] = None,
         max_input_length: Optional[int] = None,
-        checkpoint_format: Optional[str] = "gptq",
         exllama_config: Optional[Dict[str, Any]] = None,
         cache_block_outputs: bool = True,
         modules_in_block_to_quantize: Optional[List[List[str]]] = None,

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -576,7 +576,7 @@ class GPTQConfig(QuantizationConfigMixin):
             the entire block at once, we perform layer-wise quantization. As a result, each layer undergoes
             quantization using inputs that have passed through the previously quantized layers.
         checkpoint_format (`str`, *optional*, defaults to `gptq`):
-            GPTQ weight format. `gptq`(v1) is supported by both gptqmodel and auto-gptq. `gptq_v2` is only  gptqmodel only.
+            GPTQ weight format. `gptq`(v1) is supported by both gptqmodel and auto-gptq. `gptq_v2` is gptqmodel only.
         use_cuda_fp16 (`bool`, *optional*, defaults to `False`):
             Whether or not to use optimized cuda kernel for fp16 model. Need to have model in fp16.
         model_seqlen (`int`, *optional*):

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -624,7 +624,7 @@ class GPTQConfig(QuantizationConfigMixin):
         pad_token_id: Optional[int] = None,
         use_exllama: Optional[bool] = None,
         max_input_length: Optional[int] = None,
-        checkpoint_format: Optional[str] = None,
+        checkpoint_format: Optional[str] = "gptq",
         exllama_config: Optional[Dict[str, Any]] = None,
         cache_block_outputs: bool = True,
         modules_in_block_to_quantize: Optional[List[List[str]]] = None,

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -624,6 +624,7 @@ class GPTQConfig(QuantizationConfigMixin):
         pad_token_id: Optional[int] = None,
         use_exllama: Optional[bool] = None,
         max_input_length: Optional[int] = None,
+        checkpoint_format: Optional[str] = None,
         exllama_config: Optional[Dict[str, Any]] = None,
         cache_block_outputs: bool = True,
         modules_in_block_to_quantize: Optional[List[List[str]]] = None,
@@ -650,6 +651,7 @@ class GPTQConfig(QuantizationConfigMixin):
         self.disable_exllama = kwargs.pop("disable_exllama", None)
         self.cache_block_outputs = cache_block_outputs
         self.modules_in_block_to_quantize = modules_in_block_to_quantize
+        self.checkpoint_format = checkpoint_format
         self.post_init()
 
     def get_loading_attributes(self):


### PR DESCRIPTION
GPTQModel needs to use checkpoint_format to determine whether to use GPTQ or GPTQ_v2. If it is GPTQ, it needs to be converted to GPTQ_v2.