### PR TITLE
fix test_serialization_big_model_inference failed

### DIFF
--- a/tests/quantization/gptq/test_gptq.py
+++ b/tests/quantization/gptq/test_gptq.py
@@ -265,7 +265,16 @@ class GPTQTest(unittest.TestCase):
         """
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.quantized_model.save_pretrained(tmpdirname)
-            quantized_model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname, device_map=self.device_map)
+
+            quantization_config = GPTQConfig(
+                bits=self.bits,
+                group_size=self.group_size,
+                desc_act=self.desc_act,
+                sym=self.sym,
+                use_exllama=self.use_exllama,
+            )
+            quantized_model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname, device_map=self.device_map,
+                                                                              quantization_config=quantization_config)
             self.check_inference_correctness(quantized_model_from_saved)
 
 


### PR DESCRIPTION
Fix the device error: `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0!` mentioned by [MekkCyber commented](https://github.com/huggingface/transformers/pull/35012#issuecomment-2556930206).

Optimum has also been modified. [PR#2134](https://github.com/huggingface/optimum/pull/2134)